### PR TITLE
Change the defintion of interface atoms in calc_pairwise_atom.inp

### DIFF
--- a/calc_pairwise_atom.inp
+++ b/calc_pairwise_atom.inp
@@ -63,8 +63,8 @@ end
 ! Get interfacial residues of chain A (receptor)
 ! Assume chains A & B
 !
-do (store1 = 1) (byres (segid A and
-                        (not segid A) around $interface_dist_cutoff))
+do (store1 = 1) (segid A and
+                        (not segid A) around $interface_dist_cutoff)
 
 evaluate ($buffer_file = $coorfile - ".pdb" + ".pwa_ene")
 buffer energies to=file=$buffer_file end
@@ -80,7 +80,7 @@ for $id_a in id (attr store1 = 1) loop res_a
     show (name) (id $id_a)
     evaluate ($name_a = $result)
 
-    for $id_b in id ( segid B and (segid A and resid $resi_a) around $interface_dist_cutoff ) loop res_b
+    for $id_b in id ( segid B and (segid A and resid $resi_a and name $name_a) around $interface_dist_cutoff ) loop res_b
         show (resid) (id $id_b)
         evaluate ($resi_b = $result)
         show (resn) (id $id_b)


### PR DESCRIPTION
The definition of interface you used in "calc_pairwise_atom.inp" is based on residue level, but we'd like to use this script to calculate atom-atom interactions, so I think it's better to use the atom-based interface. Otherwise we would get energies of atoms whose distance is larger than  the "interface_dist_cutoff".

I compared the example result of atom-atom energy with that of Li's script, everything is consistent except the hydrogen-hydrogen vdw energies. After calculating those energies by hand, and I found that the cns will use "PARAM19" vdw parameters for hydrogen atoms but not "OPLSX" vdw parameters. Here is an example of hydrogen-hydrogen interaction for e2a_hpr.pdb:

> ATOM    498  HE2 HIS    75      -1.618  -7.956   2.795  1.00 10.00      A
> ATOM   1509  HD1 HIS    15       2.041  -8.905   4.381  1.00 10.00      B

**e2a_hpr.pwa_ene  line 848:**
**# A 75 HIS HE2 <> B 15 HIS HD1 - _vdW = -3.514641E-04_ elec = 10.0946**
but the actual vdw energy should be 
**# A 75 HIS HE2 <> B 15 HIS HD1 - _vdW = -6.585504E-07_ elec = 10.0946**

In protein-allhdg5-4.param,
**OPLSX parameters**

> 1447  NONBonded  H       0.05     0.50        0.004     0.50
> 1448  NONBonded  HA      0.05     0.50        0.004     0.50
> 1449  NONBonded  HC      0.05     0.50        0.004     0.50
> **PARAM19 parameters**
> 1501  NONBonded  H       0.0498   1.4254      0.0498   1.4254
> 1502 NONBonded  HA      0.0498   1.4254      0.0450   2.6157 !- charged group.
> 1503 NONBonded  HC      0.0498   1.0691      0.0498   1.0691 !   Reduced vdw radius

I have no idea why cns does not use default parameters. Please check it, thank U:-)
